### PR TITLE
(refactor) Added webpack dev server and gulpfile

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "stage-0", "react"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+.DS_Store
+npm-debug.log

--- a/client/index.html
+++ b/client/index.html
@@ -9,6 +9,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script src="../dist/bundle.js" async></script>
+    <script src="./index.js" async></script>
   </body>
 </html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,47 @@
+// dev - launches lazy loaded dev server @localhost:8000
+// webpack - bundles all files into dist @ index.js
+// copy - copies all build related dependencies into proper dist folders
+// build - webpack + copy, dist file should be ready to serve
+// watch - builds on change
+
+
+var gulp = require('gulp');
+var webpack = require('webpack');
+var WebpackDevServer = require('webpack-dev-server');
+var webpackConfig = require('./webpack.config');
+var serverConfig = require('./webpack.dev.server.config');
+
+gulp.task('dev', function() {
+  var server = new WebpackDevServer(webpack(webpackConfig), serverConfig);
+  server.listen(8000, 'localhost', function(err) {
+    console.log(err || 'server listening on localhost:8000');
+  });
+});
+
+gulp.task('webpack', function() {
+  webpack(webpackConfig, function(err) {
+    console.log(err || 'Success: dist updated');
+  });
+});
+
+gulp.task('copy', function() {
+  gulp.src('./client/index.html')
+    .pipe(gulp.dest('./dist'));
+  gulp.src('./client/styles/styles.css')
+    .pipe(gulp.dest('./dist/styles'));
+  gulp.src('./client/assets/*.*')
+    .pipe(gulp.dest('./dist/assets'))
+});
+
+gulp.task('build', ['webpack', 'copy']);
+
+gulp.task('watch', function(){
+  gulp.watch([
+    './client/*.*',
+    '.client/**/*.js',
+    '.client/**/*.jsx',
+    '.client/**/*.css'
+    ], ['webpack','copy']);
+});
+
+

--- a/package.json
+++ b/package.json
@@ -4,13 +4,12 @@
   "description": "Fantasy sports for Game of Thrones",
   "main": "./client/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start":"gulp dev"
   },
   "author": "Naomi Jacobs",
   "license": "ISC",
   "dependencies": {
-    "babel": "^6.1.18",
-    "babel-core": "^6.2.1",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "react-redux": "^4.0.0",
@@ -18,10 +17,15 @@
     "redux-thunk": "^1.0.0"
   },
   "devDependencies": {
+    "babel-core": "^6.2.1",
     "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
+    "babel-preset-stage-0": "^6.0.15",
+    "gulp": "^3.9.0",
+    "react-hot-loader": "^1.3.0",
     "redux-devtools": "^2.1.5",
-    "webpack": "^1.12.8"
+    "webpack": "^1.12.8",
+    "webpack-dev-server": "^1.12.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,21 +1,27 @@
+var path = require('path');
+var webpack = require('webpack');
+
 module.exports = {
-
-  entry: './client/index.js',
+  devtool: 'eval',
+  entry: [
+    'webpack-dev-server/client?http://localhost:8000',
+    'webpack/hot/only-dev-server',
+    './client/index.js',
+  ],
   output: {
-    path: './dist',
-    filename: 'bundle.js',
+    path: path.join(__dirname, 'dist'),
+    filename: 'index.js',
+    publicPath: '/client/'
   },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin()
+  ],
   module: {
-    loaders: [
-      {
-        test: /\.jsx?$/,
-        exclude: /node_modules/,
-        loader: 'babel',
-        query: {
-          presets: ['react', 'es2015'],
-        }
-      },
-    ]
-  }
-
+    loaders: [{
+      test: /\.(js|jsx)?$/,
+      loaders: ['react-hot', 'babel'],
+      exclude: 'node_modules',
+      include: path.join(__dirname, 'client'),
+    }]
+  },
 };

--- a/webpack.dev.server.config.js
+++ b/webpack.dev.server.config.js
@@ -1,0 +1,8 @@
+var config = require('./webpack.config');
+module.exports = {
+  publicPath: config.output.publicPath,
+  hot: true,
+  stats:{
+    colors: true
+  }
+};


### PR DESCRIPTION
we now have a dev server that can lazy load components on the fly and a gulp file that builds our js/css/html/assets to dist/. dist/ can be served as a stand alone compacted client folder.