### PR TITLE
(feat) flexboxed main page and added dev server/gulpfile

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "stage-0", "react"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+.DS_Store
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Fantasy Game of Thrones
+
+----
+## Introduction
+see [Game of Thrones Wikipedia](https://en.wikipedia.org/wiki/Game_of_Thrones)
+
+This provides a platform for a game of thrones fantasy league.
+
+## Tech Stack
+
+Python? + React/Redux + Redis?
+
+----
+## Getting started (dev)
+* `npm install`
+* `gulp dev`
+
+Dev server should now serve files from http://localhost:8000/client. React components should be auto-updated, without need of browser refresh. 
+
+----
+## Getting started (prod)
+* `npm install`
+* `gulp build`
+
+----
+## Dependencies
+* [react](https://github.com/facebook/react)
+* [react-dom](https://www.npmjs.com/package/react-dom)
+* [react-redux](https://github.com/rackt/react-redux)
+* [redux](https://github.com/rackt/redux)
+* [redux-thunk](https://github.com/gaearon/redux-thunk)

--- a/client/app.jsx
+++ b/client/app.jsx
@@ -8,11 +8,21 @@ import TeamTable from './components/teamTable.jsx';
 let App = React.createClass({
 
   render() {
-    return <div>
-      <CharacterTable />
-      <PlayerTable />
-      <TeamTable />
-    </div>;
+    return (
+      <div id="composedApp">
+        <div id="header"><h1>Fantasy Game of Thrones</h1></div>
+        <div id="body">
+          <div id="left"><h1>Left Panel</h1></div>
+          <div id="center">
+            <CharacterTable />
+            <PlayerTable />
+            <TeamTable />
+          </div>
+          <div id="right"><h1>Right Panel</h1></div>
+        </div>
+        <div id="footer"><h1>Footer</h1></div>
+      </div>
+    );
   },
 
 });

--- a/client/index.html
+++ b/client/index.html
@@ -9,6 +9,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script src="../dist/bundle.js" async></script>
+    <script src="./index.js" async></script>
   </body>
 </html>

--- a/client/styles/styles.css
+++ b/client/styles/styles.css
@@ -2,8 +2,19 @@
   font-family: 'gameOfThrones',
   src: url('../assets/gameofthrones.ttf');
 }*/
+
+/* HTML5 display-role reset for older browsers */
+
+
+#app {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+}
 #composedApp {
   display: flex;
+  width: 100%;
+  height: 100%;
   flex-direction: column;
   margin: 0 auto;
 }
@@ -23,7 +34,7 @@
   align-items: center;
   justify-content: space-around;
   background: lightpink;
-  flex: 1;
+  flex: 1 0 30em;
 }
 #left, #right {
    background: lightskyblue;
@@ -36,8 +47,11 @@
 body {
   background-image: url('../assets/mochaGrunge.png');
   font-family: 'Montserrat', sans-serif;
+  margin: 0;
 }
-
+ol, ul {
+  list-style: none;
+}
 table {
   border: black 2px solid;
 }

--- a/client/styles/styles.css
+++ b/client/styles/styles.css
@@ -2,6 +2,36 @@
   font-family: 'gameOfThrones',
   src: url('../assets/gameofthrones.ttf');
 }*/
+#composedApp {
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+}
+#header, #footer{
+  display: flex;
+  justify-content: center;
+  background:palegreen;
+}
+#body {
+  display: flex;
+  flex: 1;
+}
+#center {
+  display: flex;
+  overflow: scroll;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-around;
+  background: lightpink;
+  flex: 1;
+}
+#left, #right {
+   background: lightskyblue;
+   flex: 0 0 12em;
+}
+#left {
+  order: -1;
+}
 
 body {
   background-image: url('../assets/mochaGrunge.png');
@@ -27,3 +57,5 @@ table caption {
 .characterTable .playerTable .teamTable {
   float: left;
 }
+
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,47 @@
+// dev - launches lazy loaded dev server @localhost:8000
+// webpack - bundles all files into dist @ index.js
+// copy - copies all build related dependencies into proper dist folders
+// build - webpack + copy, dist file should be ready to serve
+// watch - builds on change
+
+
+var gulp = require('gulp');
+var webpack = require('webpack');
+var WebpackDevServer = require('webpack-dev-server');
+var webpackConfig = require('./webpack.config');
+var serverConfig = require('./webpack.dev.server.config');
+
+gulp.task('dev', function() {
+  var server = new WebpackDevServer(webpack(webpackConfig), serverConfig);
+  server.listen(8000, 'localhost', function(err) {
+    console.log(err || 'server listening on localhost:8000');
+  });
+});
+
+gulp.task('webpack', function() {
+  webpack(webpackConfig, function(err) {
+    console.log(err || 'Success: dist updated');
+  });
+});
+
+gulp.task('copy', function() {
+  gulp.src('./client/index.html')
+    .pipe(gulp.dest('./dist'));
+  gulp.src('./client/styles/styles.css')
+    .pipe(gulp.dest('./dist/styles'));
+  gulp.src('./client/assets/*.*')
+    .pipe(gulp.dest('./dist/assets'))
+});
+
+gulp.task('build', ['webpack', 'copy']);
+
+gulp.task('watch', function(){
+  gulp.watch([
+    './client/*.*',
+    '.client/**/*.js',
+    '.client/**/*.jsx',
+    '.client/**/*.css'
+    ], ['webpack','copy']);
+});
+
+

--- a/package.json
+++ b/package.json
@@ -4,13 +4,12 @@
   "description": "Fantasy sports for Game of Thrones",
   "main": "./client/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start":"gulp dev"
   },
   "author": "Naomi Jacobs",
   "license": "ISC",
   "dependencies": {
-    "babel": "^6.1.18",
-    "babel-core": "^6.2.1",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "react-redux": "^4.0.0",
@@ -18,10 +17,15 @@
     "redux-thunk": "^1.0.0"
   },
   "devDependencies": {
+    "babel-core": "^6.2.1",
     "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
+    "babel-preset-stage-0": "^6.0.15",
+    "gulp": "^3.9.0",
+    "react-hot-loader": "^1.3.0",
     "redux-devtools": "^2.1.5",
-    "webpack": "^1.12.8"
+    "webpack": "^1.12.8",
+    "webpack-dev-server": "^1.12.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,21 +1,27 @@
+var path = require('path');
+var webpack = require('webpack');
+
 module.exports = {
-
-  entry: './client/index.js',
+  devtool: 'eval',
+  entry: [
+    'webpack-dev-server/client?http://localhost:8000',
+    'webpack/hot/only-dev-server',
+    './client/index.js',
+  ],
   output: {
-    path: './dist',
-    filename: 'bundle.js',
+    path: path.join(__dirname, 'dist'),
+    filename: 'index.js',
+    publicPath: '/client/'
   },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin()
+  ],
   module: {
-    loaders: [
-      {
-        test: /\.jsx?$/,
-        exclude: /node_modules/,
-        loader: 'babel',
-        query: {
-          presets: ['react', 'es2015'],
-        }
-      },
-    ]
-  }
-
+    loaders: [{
+      test: /\.(js|jsx)?$/,
+      loaders: ['react-hot', 'babel'],
+      exclude: 'node_modules',
+      include: path.join(__dirname, 'client'),
+    }]
+  },
 };

--- a/webpack.dev.server.config.js
+++ b/webpack.dev.server.config.js
@@ -1,0 +1,8 @@
+var config = require('./webpack.config');
+module.exports = {
+  publicPath: config.output.publicPath,
+  hot: true,
+  stats:{
+    colors: true
+  }
+};


### PR DESCRIPTION
readme (bd0e461) - readme added

cleanup (71b1306) - made app full screen

flexbox layout (9a6d319) - Flexbox display created. Currently using dummy colors to illustrate dopeness of layout.

webpack/gulpfile (d6fbfb7) - Dev server can lazy load components on the fly and gulpfile that builds our js/css/html/assets to dist/. dist/ can be served as a stand alone compacted client folder.
